### PR TITLE
Merge community-admin manual events into /api/events (V6 Source C)

### DIFF
--- a/api/events.py
+++ b/api/events.py
@@ -9,6 +9,7 @@ Telegram events are re-enriched at read time to pick up changes
 
 import json
 import logging
+import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from http.server import BaseHTTPRequestHandler
 from urllib.parse import urlparse, parse_qs
@@ -113,6 +114,30 @@ def _refresh_event_metadata(events: list[dict]) -> None:
                 event["location"] = fresh["location"]
 
 
+def _fetch_manual_events() -> list[dict]:
+    """Fetch manually-created events from community-admin (Source C, V6).
+
+    Additive and best-effort: any fetch/parse failure (missing config,
+    network error, malformed payload) logs a warning and returns [] so
+    Telegram + Luma/guildhost sources are never affected. Callers still
+    owe the visibility filter (see do_GET) — this returns every manual
+    event community-admin has, unscoped.
+    """
+    url = config.manual_events_url()
+    if not url or not config.CA_CONFIG_SECRET:
+        return []
+    try:
+        req = urllib.request.Request(
+            url, headers={"Authorization": f"Bearer {config.CA_CONFIG_SECRET}"}
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read().decode())
+        return payload.get("events", [])
+    except Exception as e:
+        logger.warning(f"manual events fetch failed, skipping: {e}")
+        return []
+
+
 class handler(BaseHTTPRequestHandler):
     def do_GET(self):
         parsed = urlparse(self.path)
@@ -166,8 +191,14 @@ class handler(BaseHTTPRequestHandler):
         api_urls = {_normalize_url(e["url"]) for e in api_events}
         tg_events = [e for e in tg_events if _normalize_url(e["url"]) not in api_urls]
 
+        # Source C: manual events from community-admin (community-admin#6, V6).
+        # Filtered against `groups`, which is ALREADY visibility-filtered above
+        # (config.visible_groups) — so a private community the caller isn't a
+        # member of is dropped here automatically, same as Sources A and B.
+        manual_events = [e for e in _fetch_manual_events() if e.get("community") in groups]
+
         # Merge and sort by starts_at ascending, nulls last
-        all_events = api_events + tg_events
+        all_events = api_events + tg_events + manual_events
         all_events.sort(key=lambda e: (e.get("starts_at") is None, e.get("starts_at") or ""))
 
         self.send_response(200)

--- a/lib/config.py
+++ b/lib/config.py
@@ -24,6 +24,19 @@ SUPABASE_SERVICE_KEY = os.getenv("SUPABASE_SERVICE_KEY")
 CA_CONFIG_URL = os.getenv("CA_CONFIG_URL")
 CA_CONFIG_SECRET = os.getenv("CA_CONFIG_SECRET")
 
+def manual_events_url() -> str | None:
+    """Derive the community-admin manual-events endpoint from CA_CONFIG_URL.
+
+    community-admin exposes manual events (V6) at GET /api/events/manual,
+    a sibling of the /api/config endpoint this module already reads.
+    Returns None when the config-seam env var is unset (no manual events
+    integration configured), matching CA_CONFIG_URL's own convention.
+    """
+    if not CA_CONFIG_URL:
+        return None
+    return CA_CONFIG_URL.replace("/api/config", "/api/events/manual")
+
+
 # In Vercel, __file__ is in lib/, JSON configs are in project root
 _PROJECT_ROOT = Path(__file__).parent.parent
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,3 +25,13 @@ def test_member_ids_matched_as_strings():
 def test_none_member_ids_treated_as_empty():
     groups = {"7": {"visibility": "private"}, "8": {"visibility": "public"}}
     assert set(config.visible_groups(groups)) == {"8"}
+
+
+def test_manual_events_url_derived_from_ca_config_url(monkeypatch):
+    monkeypatch.setattr(config, "CA_CONFIG_URL", "https://ca.example.com/api/config")
+    assert config.manual_events_url() == "https://ca.example.com/api/events/manual"
+
+
+def test_manual_events_url_none_when_ca_config_url_unset(monkeypatch):
+    monkeypatch.setattr(config, "CA_CONFIG_URL", None)
+    assert config.manual_events_url() is None

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,239 @@
+"""Tests for GET /api/events — Source C (manual events, community-admin#6 / V6).
+
+Sources A (Telegram/Supabase) and B (Luma/guild.host) are stubbed so these
+tests exercise the merge + visibility-gate logic in isolation, no real
+network/DB I/O, mirroring how tests/test_config.py isolates lib.config's
+own network calls.
+
+Coverage required by the task brief:
+- a manual event whose community IS in the visible `groups` is merged
+- one whose community is NOT in `groups` (private, or unknown) is dropped
+- a fetch failure inside _fetch_manual_events degrades gracefully —
+  Telegram + Luma events are still returned, and no exception propagates
+"""
+
+import io
+import json
+import urllib.error
+import urllib.request
+
+import pytest
+
+from api import events as events_module
+from lib import config
+
+
+# Two communities: "visible" is public, "private" is private with no caller
+# membership (the handler is invoked with no Authorization header below), so
+# config.visible_groups drops it before Source C ever sees it.
+GROUPS = {
+    "visible": {
+        "group_id": "111",
+        "visibility": "public",
+        "event_apis": [
+            {"type": "luma", "url": "https://lu.ma/visible-cal", "api_id": "visible-cal"},
+        ],
+    },
+    "private": {
+        "group_id": "222",
+        "visibility": "private",
+        "event_apis": [],
+    },
+}
+
+TG_LINK = {
+    "id": 1,
+    "og_title": "TG Meetup",
+    "title": None,
+    "og_description": None,
+    "description": None,
+    "og_image": None,
+    "url": "https://example.com/tg-meetup",
+    "event_starts_at": "2026-08-01T18:00:00Z",
+    "event_location": "Some place",
+    "group_id": "111",
+}
+
+LUMA_EVENT = {
+    "id": "luma-abc123",
+    "title": "Luma Event",
+    "description": "",
+    "image": None,
+    "url": "https://luma.com/abc123",
+    "starts_at": "2026-08-02T18:00:00Z",
+    "ends_at": None,
+    "location": None,
+    "source": "luma",
+    "community": "visible",
+}
+
+
+@pytest.fixture(autouse=True)
+def stub_sources(monkeypatch):
+    """Isolate the handler from real network/DB calls for Sources A and B."""
+    monkeypatch.setattr(config, "get_all_event_groups", lambda: dict(GROUPS))
+    monkeypatch.setattr(events_module, "get_event_links", lambda group_ids=None: [dict(TG_LINK)])
+    monkeypatch.setattr(events_module, "enrich_event", lambda url: {})
+    monkeypatch.setattr(
+        events_module, "fetch_luma_events",
+        lambda url, key, api_id=None: [dict(LUMA_EVENT)],
+    )
+    monkeypatch.setattr(events_module, "fetch_guildhost_events", lambda url, key: [])
+
+
+def _invoke(path="/api/events", headers=None):
+    """Build a handler instance and call do_GET without a real socket.
+
+    BaseHTTPRequestHandler.__init__ normally drives the socket handshake, so
+    we bypass it via __new__ and set only the attributes send_response /
+    send_header / end_headers actually touch.
+    """
+    h = events_module.handler.__new__(events_module.handler)
+    h.path = path
+    h.headers = headers or {}
+    h.client_address = ("127.0.0.1", 12345)
+    h.request_version = "HTTP/1.1"
+    h.requestline = f"GET {path} HTTP/1.1"
+    h.rfile = io.BytesIO()
+    h.wfile = io.BytesIO()
+    h.do_GET()
+    raw = h.wfile.getvalue()
+    _, _, body = raw.partition(b"\r\n\r\n")
+    return json.loads(body.decode())
+
+
+class _FakeResponse:
+    """Minimal stand-in for the urlopen() context manager."""
+
+    def __init__(self, payload: dict):
+        self._payload = json.dumps(payload).encode()
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+# --- handler-level tests -----------------------------------------------
+
+def test_manual_event_in_visible_group_is_merged(monkeypatch):
+    manual_event = {
+        "id": "manual-1",
+        "title": "Manual Meetup",
+        "description": "",
+        "image": None,
+        "url": "https://example.com/manual-event",
+        "starts_at": "2026-08-03T18:00:00Z",
+        "ends_at": None,
+        "location": "HQ",
+        "source": "manual",
+        "community": "visible",
+    }
+    monkeypatch.setattr(events_module, "_fetch_manual_events", lambda: [manual_event])
+
+    body = _invoke()
+
+    ids = {e["id"] for e in body["events"]}
+    assert "manual-1" in ids
+    merged = next(e for e in body["events"] if e["id"] == "manual-1")
+    assert merged["source"] == "manual"
+    assert merged["community"] == "visible"
+    # Sources A and B are untouched by the additive merge.
+    assert "tg-1" in ids
+    assert "luma-abc123" in ids
+
+
+def test_manual_event_in_non_visible_group_is_dropped(monkeypatch):
+    hidden_events = [
+        {  # private community — caller has no membership (no auth header)
+            "id": "manual-private",
+            "title": "Private Event",
+            "url": "https://example.com/private-event",
+            "starts_at": "2026-08-04T18:00:00Z",
+            "ends_at": None,
+            "location": None,
+            "source": "manual",
+            "community": "private",
+        },
+        {  # community key not present in config at all
+            "id": "manual-unknown",
+            "title": "Unknown Community Event",
+            "url": "https://example.com/unknown-event",
+            "starts_at": "2026-08-05T18:00:00Z",
+            "ends_at": None,
+            "location": None,
+            "source": "manual",
+            "community": "does-not-exist",
+        },
+    ]
+    monkeypatch.setattr(events_module, "_fetch_manual_events", lambda: hidden_events)
+
+    body = _invoke()
+
+    ids = {e["id"] for e in body["events"]}
+    assert "manual-private" not in ids
+    assert "manual-unknown" not in ids
+    # Telegram + Luma are unaffected by the drop.
+    assert "tg-1" in ids
+    assert "luma-abc123" in ids
+
+
+def test_handler_degrades_gracefully_when_manual_fetch_fails(monkeypatch):
+    """A real network failure inside _fetch_manual_events must never break
+    the feed — Telegram + Luma results still come back, no exception."""
+    monkeypatch.setattr(config, "CA_CONFIG_URL", "https://ca.example.com/api/config")
+    monkeypatch.setattr(config, "CA_CONFIG_SECRET", "secret")
+
+    def _raise(*args, **kwargs):
+        raise urllib.error.URLError("boom")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _raise)
+
+    body = _invoke()
+
+    sources = {e["source"] for e in body["events"]}
+    assert "telegram" in sources
+    assert "luma" in sources
+    assert not any(e["source"] == "manual" for e in body["events"])
+
+
+# --- _fetch_manual_events unit tests ------------------------------------
+
+def test_fetch_manual_events_returns_empty_without_ca_config_url(monkeypatch):
+    monkeypatch.setattr(config, "CA_CONFIG_URL", None)
+    assert events_module._fetch_manual_events() == []
+
+
+def test_fetch_manual_events_returns_empty_without_secret(monkeypatch):
+    monkeypatch.setattr(config, "CA_CONFIG_URL", "https://ca.example.com/api/config")
+    monkeypatch.setattr(config, "CA_CONFIG_SECRET", None)
+    assert events_module._fetch_manual_events() == []
+
+
+def test_fetch_manual_events_network_failure_returns_empty(monkeypatch):
+    monkeypatch.setattr(config, "CA_CONFIG_URL", "https://ca.example.com/api/config")
+    monkeypatch.setattr(config, "CA_CONFIG_SECRET", "secret")
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **kw: (_ for _ in ()).throw(urllib.error.URLError("boom")))
+
+    assert events_module._fetch_manual_events() == []
+
+
+def test_fetch_manual_events_malformed_payload_returns_empty(monkeypatch):
+    monkeypatch.setattr(config, "CA_CONFIG_URL", "https://ca.example.com/api/config")
+    monkeypatch.setattr(config, "CA_CONFIG_SECRET", "secret")
+    monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=5: _FakeResponse({"not_events": []}))
+
+    assert events_module._fetch_manual_events() == []
+
+
+def test_fetch_manual_events_parses_events_key(monkeypatch):
+    monkeypatch.setattr(config, "CA_CONFIG_URL", "https://ca.example.com/api/config")
+    monkeypatch.setattr(config, "CA_CONFIG_SECRET", "secret")
+    payload = {"events": [{"id": "m1", "community": "visible"}]}
+    monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=5: _FakeResponse(payload))
+
+    assert events_module._fetch_manual_events() == payload["events"]


### PR DESCRIPTION
The scenius-digest half of community-admin V6 (manual events). Adds community-admin's manually-created events as a third source in `GET /api/events`, so they appear in the My Community / Dear Neighbors participation feeds alongside Telegram and Luma/guild.host events.

## What's in this PR

- **`lib/config.py`** — `manual_events_url()` derives community-admin's `/api/events/manual` endpoint from the existing `CA_CONFIG_URL` (sibling of `/api/config`); returns `None` when unconfigured. No new env var — reuses `CA_CONFIG_URL` / `CA_CONFIG_SECRET`.
- **`api/events.py`** — `_fetch_manual_events()` (Bearer-authed, best-effort) + Source C in `do_GET`. Manual events are merged into `all_events`.

## Two properties worth calling out

- **Visibility is inherited, not re-implemented.** Source C filters `e["community"] in groups`, and `groups` is already run through `config.visible_groups(...)` earlier in `do_GET` — so a private community the caller isn't a member of is dropped automatically, exactly like Sources A and B.
- **Strictly additive / never breaks the feed.** Any fetch/parse failure (unset config, network error, malformed payload) logs a warning and returns `[]`; Telegram + Luma continue unaffected.

## Tests

`python -m pytest`: 21 passed (11 baseline + 10 new — `manual_events_url()` in `test_config.py`, plus handler-level merge/drop/graceful-degrade + `_fetch_manual_events` units in a new `test_events.py`). No pre-existing or new failures.

## Depends on / deploy order

- Consumes community-admin's `GET /api/events/manual` (Citizen-Infra/community-admin PR #37). Merge + deploy that PR first so the endpoint is live, then this one.
- For an end-to-end demo ("create event → see it in the feed"), the demo community must be in scenius-digest's `groups` set — i.e. have a Telegram `group_id` (via `/api/config`) or an `event_sources.json` entry. A manual event for an active community absent from `groups` is fetched but filtered out before the feed.